### PR TITLE
If you don't have the dat-cli this won't work, but doesn't tell you.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,11 @@ Read the [docs](https://github.com/maxogden/dat) to learn more about Dat.
 
 ## Installation
 
-  1. Install pip
+  1. Install[dat](https://github.com/maxogden/dat)
 
-  2. Obtain the Python DAT package
+  2. Install pip
+
+  3. Obtain the Python DAT package
 
     `pip install datpy`
 

--- a/dat.py
+++ b/dat.py
@@ -1,5 +1,4 @@
 import subprocess
-import time
 import cPickle
 
 try:
@@ -28,8 +27,12 @@ def clone(URL, path, **kwargs):
   """
   p = process("dat clone {0} {1}".format(URL, path), kwargs)
   stdout, stderr = p.communicate()
-  if (p.returncode == 0):
+  if p.returncode == 0:
     return Dat(path)
+  elif p.returncode == 127:
+    print("It looks like `dat` commandline is missing from PATH.\n",
+          "Are you sure you installed it?\n"
+          "Check http://dat-data.com for instructions")
   else:
    return p.returncode
 

--- a/dat.py
+++ b/dat.py
@@ -30,9 +30,9 @@ def clone(URL, path, **kwargs):
   if p.returncode == 0:
     return Dat(path)
   elif p.returncode == 127:
-    print("It looks like `dat` commandline is missing from PATH.\n",
-          "Are you sure you installed it?\n"
-          "Check http://dat-data.com for instructions")
+    raise Exception("It looks like `dat` commandline is missing from PATH.\n",
+                    "Are you sure you installed it?\n"
+                    "Check http://dat-data.com for instructions")
   else:
    return p.returncode
 


### PR DESCRIPTION
Hi Karissa,

I was playing around with the several dat api's, to see if I could help out a bit, and understand what's going on.
When I started with the datpy lib, I noticed a couple of things, which I tried to fix in this PR.

1. The dat-cli needs to be installed, this isn't mentioned in the README
2. There is no real exception handling for this. I'm not sure how you're going to go about this. I just send a message to the exception for now.

On a very unrelated note: you use 2 indents instead of the pep8 standard of 4. Is this a deliberate choice? If not, it might be nice to try out the `flake8` python package and run it on your code.

    pip install flake8
    flake8 dat.py
I'll send another pull-request fixing that, which you can choose to ignore or not.

Fritz