### PR TITLE
Python3 Support (fixes #4)

### DIFF
--- a/datpy.py
+++ b/datpy.py
@@ -1,6 +1,9 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import pickle
 import subprocess
 import time
-import cPickle
 
 try:
   import ujson as json
@@ -32,7 +35,7 @@ def returns_version(func):
 
   return inner
 
-class Dat:
+class Dat(object):
 
   def __init__(self, path=None):
     self.path = path
@@ -83,7 +86,7 @@ class Dat:
   def dataset(self, name):
     return Dataset(self, name)
 
-class Dataset:
+class Dataset(object):
 
   def __init__(self, dat, dataset):
     self.dat = dat
@@ -144,7 +147,7 @@ def process(cmd, opts):
 
   cmd += ' --json '
 
-  for key, val in opts.iteritems():
+  for key, val in opts.items():
     if (len(key) == 1):
       cmd += " -{0} {1}".format(key, val)
     else:

--- a/datpy.py
+++ b/datpy.py
@@ -167,11 +167,13 @@ def stream_in(p, data):
     TODO: if true, will try to parse the output from python generator or list
 
   """
+  if isinstance(data, str):
+    data = data.encode()
   stdout, stderr = p.communicate(input=data)
   if p.returncode == 1:
     raise DatException('Node.js error: ' + stderr)
   else:
-    res = json.loads(stdout)
+    res = json.loads(stdout.decode())
     if type(res) == object and res.get('error'):
       return on_error(res)
     return res
@@ -188,11 +190,11 @@ def stream_out(p, parse=True):
     to parse the file into json
   """
   res = []
-  for line in iter(p.stdout.readline, ''):
+  for line in iter(p.stdout.readline, b''):
     if parse:
-      line = json.loads(line.rstrip())
+      line = json.loads(line.decode().rstrip())
     else:
-      line = line
+      line = line.decode()
     res.append(line)
 
   if len(res) == 1:

--- a/datpy.py
+++ b/datpy.py
@@ -92,7 +92,9 @@ class Dataset:
   def keys(self, **kwargs):
     p = self.process("dat keys", kwargs)
     res = stream_out(p)
-    return res['keys']
+    if 'keys' in res:
+      return res['keys']
+    return res
 
   @returns_version
   def import_file(self, filename, **kwargs):

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,6 +1,9 @@
-import unittest
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
 import json
-import cPickle
+import pickle
+import unittest
 
 from datpy import Dat, Dataset
 
@@ -83,12 +86,12 @@ class IOTests(DatTest):
       "hello": "mars",
       "goodbye": "world"
     }
-    data = cPickle.dumps(my_python_object)
+    data = pickle.dumps(my_python_object)
     version = self.dat.write("helloworld.pickle", data=data)
     self.assertEqual(len(version), 64)
 
     data = self.dat.read("helloworld.pickle")
-    obj = cPickle.loads(data)
+    obj = pickle.loads(data)
     self.assertEqual(type(obj), dict)
     self.assertEqual(obj["hello"], "mars")
 
@@ -112,7 +115,7 @@ class TestPandas(DatTest):
     self.assertEqual(len(output), 770)
 
     df = dataset.export_dataframe()
-    keys = dataset.keys()
+    keys = list(dataset.keys())
     df['key'] = pd.Series(keys)
 
     # modify a column

--- a/tests/test.py
+++ b/tests/test.py
@@ -30,7 +30,7 @@ class IsolatedTest(DatTest):
     self.assertEqual(len(output), 770)
 
     status = self.dat.status()
-    self.assertEqual(status['datasets'], 2)
+    self.assertEqual(status['datasets'], 1)
     self.assertEqual(status['files'], 1)
     #self.assertEqual(status['rows'], 770)
 


### PR DESCRIPTION
Fixes errors in Python 3 (issue #4). The main issue is `stdout` and `stdin` are byte strings, not regular strings. We need to encode before passing to stdin and decode after getting data from stdout. 

All tests pass in Python 2.

***Pickle Test Failing in Python 3***: Unfortunately, things are a bit more complicated w/ Python 3 and reading the pickle file. We can't decode the stdout byte string because it is a pickle file, so we get a `UnicodeDecodeError`. To fix that, we'd have to add this into `stream_out`:
```python
try:
  line = line.decode()
except UnicodeDecodeError:
  line = pickle.loads(line)
  parse = True # avoid creating string later, since we want object
```
Or potentially create a separate read function for pickle files. Neither of these seem like good solutions though. So, not quite sure what to do there and open to suggestions.